### PR TITLE
tests(.travis.yml): run linting and unit tests in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+go: 1.6
+go_import_path: github.com/docker/distribution
+before_install:
+    - go get github.com/tools/godep
+    - godep restore
+    - go get github.com/golang/lint/golint
+script:
+    - make fmt lint vet test


### PR DESCRIPTION
Adds a `.travis.yml` file to run docker/distribution's linting and unit tests at https://travis-ci.org/deis/distribution so we can ensure changes to our "minio" branch don't break general functionality.

cc: @kmala
