### PR TITLE
fix(gcs): always build in GCS support

### DIFF
--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -13,8 +13,6 @@
 // guarantee is that once you call Stat and receive a certain file size, that much of
 // the file is already accessible.
 //
-// +build include_gcs
-
 package gcs
 
 import (

--- a/registry/storage/driver/gcs/gcs_test.go
+++ b/registry/storage/driver/gcs/gcs_test.go
@@ -1,5 +1,3 @@
-// +build include_gcs
-
 package gcs
 
 import (


### PR DESCRIPTION
this PR removes the conditional build tag for GCS support
